### PR TITLE
Force interfaces down on Debian

### DIFF
--- a/lib/puppet/parser/functions/build_cidr_array.rb
+++ b/lib/puppet/parser/functions/build_cidr_array.rb
@@ -1,7 +1,7 @@
 module Puppet::Parser::Functions
   newfunction(:build_cidr_array, :type => :rvalue) do |args|
     unless args.length == 1 then
-      raise Puppet::ParseError, ("netmask_to_masklen(): wrong number of arguments (#{args.length}; must be 1)")
+      raise Puppet::ParseError, ("build_cidr_array(): wrong number of arguments (#{args.length}; must be 1)")
     end
     new_array = []
     args[0].each do |item|

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -596,7 +596,7 @@ define network::interface (
   $real_reload_command = $reload_command ? {
     undef => $::operatingsystem ? {
         'CumulusLinux' => 'ifreload -a',
-        default        => "ifdown ${interface}; ifup ${interface}",
+        default        => "ifdown ${interface} --force ; ifup ${interface}",
       },
     default => $reload_command,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@
 class network::params {
 
   $service_restart_exec = $::osfamily ? {
-    'Debian'  => '/sbin/ifdown -a && /sbin/ifup -a',
+    'Debian'  => '/sbin/ifdown -a --force ; /sbin/ifup -a',
     'Solaris' => '/usr/sbin/svcadm restart svc:/network/physical:default',
     default   => 'service network restart',
   }


### PR DESCRIPTION
This prevents error "ifdown: interface xxx not configured" during ifdown
and relevant "RTNETLINK answers: File exists" during ifup

## Before submitting your PR

  1. Open an **issue** and refer to its number in your PR title
  1. If it's a bug and you have the solution, go on with the PR! 
  1. If it's an enhancement, please wait for our feedback before starting to work on it
  1. Please run ```puppet-lint``` on your code and ensure it's compliant

## After submitting your PR

  1. Verify Travis checks and eventually fix the errors
  1. Feel free to ping us if we don't reply promptly 

